### PR TITLE
Updates for Redlight v4

### DIFF
--- a/include/network_interface.h
+++ b/include/network_interface.h
@@ -93,8 +93,8 @@ struct Network {
  *
  * @return IoT_Error_t - successful initialization or TLS error
  */
-IoT_Error_t iot_tls_init(Network *pNetwork, char *pRootCALocation, char *pDeviceCertLocation,
-						 char *pDevicePrivateKeyLocation, char *pDestinationURL,
+IoT_Error_t iot_tls_init(Network *pNetwork, const char *pRootCALocation, const char *pDeviceCertLocation,
+                         const char *pDevicePrivateKeyLocation, const char *pDestinationURL,
 						 uint16_t DestinationPort, uint32_t timeout_ms, bool ServerVerificationFlag);
 
 /**

--- a/src/aws_iot_shadow.c
+++ b/src/aws_iot_shadow.c
@@ -117,7 +117,7 @@ IoT_Error_t aws_iot_shadow_connect(AWS_IoT_Client *pClient, ShadowConnectParamet
 	snprintf(myThingName, MAX_SIZE_OF_THING_NAME, "%s", pParams->pMyThingName);
 	snprintf(mqttClientID, MAX_SIZE_OF_UNIQUE_CLIENT_ID_BYTES, "%s", pParams->pMqttClientId);
 
-	ConnectParams.keepAliveIntervalInSec = 600; // NOTE: Temporary fix
+	ConnectParams.keepAliveIntervalInSec = 30;// 600; is hardcoded by AWS // NOTE: Temporary fix
 	ConnectParams.MQTTVersion = MQTT_3_1_1;
 	ConnectParams.isCleanSession = true;
 	ConnectParams.isWillMsgPresent = false;


### PR DESCRIPTION
* Add `const char*` to `iot_tls_init` to remove compiler warning
* Reduce keep alive to 30s (default was 600s)